### PR TITLE
web(ui): интерфейс + корневой npm, one-command dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,892 @@
+{
+  "name": "squares-monorepo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "squares-monorepo",
+      "version": "1.0.0",
+      "workspaces": [
+        "src/main/frontend"
+      ]
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/squares-frontend": {
+      "resolved": "src/main/frontend",
+      "link": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "src/main/frontend": {
+      "name": "squares-frontend",
+      "version": "1.0.0",
+      "devDependencies": {
+        "concurrently": "^9.0.0",
+        "http-server": "^14.1.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "squares",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Squares UI + Java API runner",
+  "scripts": {
+    "serve": "http-server ./src/main/frontend -c-1 -p 5173 -a 127.0.0.1",
+    "api:win": "gradlew.bat runApi",
+    "api:unix": "./gradlew runApi",
+    "dev:win": "concurrently \"npm run serve\" \"npm run api:win\"",
+    "dev:unix": "concurrently \"npm run serve\" \"npm run api:unix\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.0.0",
+    "http-server": "^14.1.1"
+  }
+}

--- a/src/main/frontend/app.js
+++ b/src/main/frontend/app.js
@@ -1,0 +1,369 @@
+(function(){
+  /* ====== конфиг / состояние ====== */
+  var API   = window.SQUARES_API || "http://127.0.0.1:3000/api/squares/nextMove";
+
+  var CELL  = 56;                       
+  var DPR   = Math.max(1, Math.floor(window.devicePixelRatio || 1));
+
+  // state.winQuad — массив из 4 углов победного квадрата [{x,y},...]
+  var state = null; // { n, board, turn, you, history[], finished, winner, winQuad }
+  var busy  = false; // ждём ответ API
+
+  var cv   = document.getElementById('board');
+  var ctx  = cv.getContext('2d');
+  ctx.imageSmoothingEnabled = true;
+
+  var movesEl  = document.getElementById('moves');
+  var statusEl = document.getElementById('status');
+  var apiLbl   = document.getElementById('apiLabel'); if (apiLbl) apiLbl.textContent = API;
+  var wrapEl   = cv.parentElement;
+
+  document.getElementById('newBtn').onclick  = function(){ newGame(); };
+  document.getElementById('undoBtn').onclick = function(){ undo(); };
+  document.getElementById('fastBtn').onclick = function(){ autoMove(); };
+  document.getElementById('resetBtn').onclick= function(){ newGame(); };
+
+  cv.addEventListener('click', onCanvasClick);
+  window.addEventListener('resize', function(){ if(state) { resizeCanvas(state.n); renderAll(); }});
+
+  newGame();
+  requestAnimationFrame(function(){ if(state){ resizeCanvas(state.n); renderAll(); }});
+
+  /* ====== инициализация ====== */
+  function newGame(){
+    var n   = clamp(+document.getElementById('sizeInp').value || 11, 3, 50);
+    var you = document.getElementById('colorSel').value;
+
+    // всегда первым ходит белый
+    state = {
+      n:n, board:mk2D(n), turn:'W', you:you,
+      history:[], finished:false, winner:null, winQuad:null
+    };
+    movesEl.innerHTML = "";
+    resizeCanvas(n);
+    setStatus("Ваш цвет: " + (you==='W'?'White':'Black') + ". Ходит " + who(state.turn));
+    renderAll();
+
+    if (state.you === 'B') autoMove(); 
+  }
+
+  function resizeCanvas(n){
+    var pad = 32; 
+    var w = Math.max(200, wrapEl.clientWidth  - pad);
+    var h = Math.max(200, wrapEl.clientHeight - pad);
+
+    var side = Math.floor(Math.min(w, h));
+    var cell = Math.max(24, Math.floor(side / n)); 
+    CELL = cell;
+
+    var W = CELL*n, H = CELL*n;
+    cv.width = W*DPR; cv.height = H*DPR;
+    cv.style.width = W+'px'; cv.style.height = H+'px';
+    ctx.setTransform(DPR,0,0,DPR,0,0);
+  }
+
+  function mk2D(n){ var a=[],y,x; for(y=0;y<n;y++){ a[y]=[]; for(x=0;x<n;x++) a[y][x]=null; } return a; }
+
+  /* ====== взаимодействие ====== */
+  function onCanvasClick(e){
+    if (busy || state.finished) return;
+    var r = cv.getBoundingClientRect();
+    var x = Math.floor((e.clientX - r.left) / CELL);
+    var y = Math.floor((e.clientY - r.top)  / CELL);
+    if (x<0 || y<0 || x>=state.n || y>=state.n) return;
+    if (state.turn !== state.you) return;
+    if (state.board[y][x] != null) return;
+
+    place(x,y,state.you);
+    logMove(state.you, x, y);
+    if (checkFinish()) return;
+    autoMove();
+  }
+
+  function place(x,y,color){
+    state.board[y][x]=color;
+    state.history.push({x:x,y:y,c:color});
+    state.turn = opp(color);
+    setStatus("Ходит " + who(state.turn)); 
+    renderAll();
+  }
+
+  function undo(){
+    if (busy) return;
+    if (!state.history.length) return;
+    if (state.finished){ state.finished=false; state.winner=null; state.winQuad=null; }
+
+    var steps = (state.turn === state.you) ? 2 : 1;
+    while(steps-- && state.history.length){
+      var m = state.history.pop();
+      state.board[m.y][m.x]=null;
+      state.turn = m.c;
+      if (movesEl.lastElementChild) movesEl.removeChild(movesEl.lastElementChild);
+    }
+    setStatus("Ходит " + who(state.turn));
+    renderAll();
+  }
+
+  function autoMove(){
+    if (state.finished) return;
+    if (state.turn === state.you) return; 
+    if (busy) return;
+    busy = true;
+
+    var dto = { size: state.n, data: boardToString(state.board), nextPlayerColor: (state.turn==='W'?'w':'b') };
+    var aiColor = state.turn; 
+
+    xhrJSON('POST', API, dto, function(err, resp, code){
+      busy = false;
+      if (state.finished) return; 
+      if (err) { setStatus("API error: "+err); return; }
+      if (code === 204 || !resp) { 
+        state.finished = true; state.winner = null; state.winQuad=null;
+        renderAll(); 
+        return;
+      }
+
+      place(resp.x, resp.y, aiColor);
+      logMove(aiColor, resp.x, resp.y);
+      checkFinish();
+    });
+  }
+
+  /* ====== рендер ====== */
+  function renderAll(){
+    drawBoard();
+    for (var y=0;y<state.n;y++)
+      for (var x=0;x<state.n;x++)
+        if (state.board[y][x]) drawChip(x,y,state.board[y][x]);
+
+    // подсветка выигрышного квадрата (если есть)
+    if (state.finished && state.winQuad){
+      drawWinOverlay(state.winQuad, state.winner || 'W');
+    }
+
+    if (state.finished){
+      ctx.save();
+      var W = state.n*CELL, H = state.n*CELL;
+      ctx.fillStyle = 'rgba(0,0,0,.25)';
+      ctx.fillRect(0, H-36, W, 36);
+      ctx.fillStyle = 'rgba(255,255,255,.85)';
+      ctx.font = '600 16px ui-sans-serif, system-ui, -apple-system, Segoe UI';
+      ctx.textAlign = 'center';
+      ctx.fillText(finishText(), W/2, H-13);
+      ctx.restore();
+    }
+  }
+
+  function drawBoard(){
+    var n = state.n, W = n*CELL, H = n*CELL;
+
+    var g = ctx.createLinearGradient(0,0,0,H);
+    g.addColorStop(0, '#171c25'); g.addColorStop(1, '#0f141b');
+    ctx.fillStyle = g;
+    ctx.fillRect(0,0,W,H);
+
+    for (var y=0;y<n;y++){
+      for (var x=0;x<n;x++){
+        if ((x+y)%2==1){
+          ctx.fillStyle = 'rgba(255,255,255,.02)';
+          ctx.fillRect(x*CELL, y*CELL, CELL, CELL);
+        }
+      }
+    }
+
+    // сетка — «тихий неон»
+    ctx.lineWidth = 1;
+    for (var i=0;i<=n;i++){
+      var x = i*CELL + .5, y = i*CELL + .5;
+      ctx.strokeStyle = 'rgba(88,208,255,.22)'; // бирюза
+      ctx.beginPath(); ctx.moveTo(x,0); ctx.lineTo(x,H); ctx.stroke();
+      ctx.strokeStyle = 'rgba(255,116,168,.22)'; // розовый
+      ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke();
+    }
+
+    // рамка
+    ctx.strokeStyle = 'rgba(255,255,255,.12)';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(0.5,0.5,W-1,H-1);
+  }
+
+  // фишка: мягкий чип с приглушённым свечением
+  function drawChip(gx,gy,c){
+    var cx = gx*CELL + CELL/2;
+    var cy = gy*CELL + CELL/2;
+    var r  = Math.max(10, CELL*0.32);
+
+    // свечение
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    ctx.shadowBlur   = 30;
+    ctx.shadowColor  = (c==='W')? 'rgba(88,208,255,.25)' : 'rgba(255,116,168,.25)';
+    ctx.fillStyle    = 'rgba(255,255,255,.02)';
+    ctx.beginPath(); ctx.arc(cx,cy,r+1,0,Math.PI*2); ctx.fill();
+    ctx.restore();
+
+    // тень
+    ctx.save();
+    ctx.shadowColor  = 'rgba(0,0,0,.45)';
+    ctx.shadowBlur   = 18;
+    ctx.shadowOffsetX= 6;
+    ctx.shadowOffsetY= 8;
+
+    // тело
+    var g = ctx.createRadialGradient(cx - r*0.3, cy - r*0.35, r*0.3, cx, cy, r*1.05);
+    if (c==='W'){ g.addColorStop(0,'#e8eef6'); g.addColorStop(1,'#aeb9c8'); }
+    else       { g.addColorStop(0,'#96a0ab'); g.addColorStop(1,'#56606b'); }
+    ctx.fillStyle = g;
+    ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
+    ctx.restore();
+
+    // кромка и блик
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(255,255,255,.10)';
+    ctx.beginPath(); ctx.arc(cx,cy,r-1,0,Math.PI*2); ctx.stroke();
+
+    ctx.beginPath();
+    ctx.strokeStyle = 'rgba(255,255,255,.35)';
+    ctx.arc(cx - r*0.25, cy - r*0.35, r*0.55, -2.6, -0.6);
+    ctx.stroke();
+  }
+
+  /* ====== подсветка победного квадрата ====== */
+  function drawWinOverlay(win, color){
+    if (!win || win.length!==4) return;
+    var glow = (color==='W') ? 'rgba(88,208,255,.75)' : 'rgba(255,116,168,.75)';
+    var soft = (color==='W') ? 'rgba(88,208,255,.18)' : 'rgba(255,116,168,.18)';
+
+    function pt(p){ return { X:(p.x+0.5)*CELL, Y:(p.y+0.5)*CELL }; }
+    var p0 = pt(win[0]), p1 = pt(win[1]), p2 = pt(win[2]), p3 = pt(win[3]);
+
+    ctx.save();
+
+    ctx.fillStyle = soft;
+    ctx.beginPath();
+    ctx.moveTo(p0.X,p0.Y); ctx.lineTo(p1.X,p1.Y); ctx.lineTo(p2.X,p2.Y); ctx.lineTo(p3.X,p3.Y); ctx.closePath();
+    ctx.fill();
+
+    ctx.lineWidth = 3;
+    ctx.strokeStyle = glow;
+    ctx.shadowColor = glow;
+    ctx.shadowBlur = 16;
+    ctx.beginPath();
+    ctx.moveTo(p0.X,p0.Y); ctx.lineTo(p1.X,p1.Y); ctx.lineTo(p2.X,p2.Y); ctx.lineTo(p3.X,p3.Y); ctx.closePath();
+    ctx.stroke();
+
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = glow;
+    [p0,p1,p2,p3].forEach(function(pp){
+      ctx.beginPath(); ctx.arc(pp.X, pp.Y, Math.max(3, CELL*0.08), 0, Math.PI*2); ctx.fill();
+    });
+
+    ctx.restore();
+  }
+
+  /* ====== конец игры ====== */
+  function checkFinish(){
+    // ищем квадраты и забираем их вершины
+    var wQ = findSquare(state.board, 'W');
+    var bQ = findSquare(state.board, 'B');
+
+    if (wQ || bQ){
+      state.finished = true;
+      if (wQ && !bQ){ state.winner='W'; state.winQuad = wQ; }
+      else if (bQ && !wQ){ state.winner='B'; state.winQuad = bQ; }
+      else { state.winner=null; state.winQuad = wQ || bQ; } 
+      renderAll(); 
+      return true;
+    }
+
+    // ничья — всё занято и ходов больше нет
+    var full = true;
+    outer: for (var y=0;y<state.n;y++) for (var x=0;x<state.n;x++) if (state.board[y][x]==null){ full=false; break outer; }
+    if (full){
+      state.finished = true; state.winner = null; state.winQuad = null;
+      renderAll();
+      return true;
+    }
+    return false;
+  }
+
+  function finishText(){
+    if (state.winner === 'W') return "Game finished. White wins!";
+    if (state.winner === 'B') return "Game finished. Black wins!";
+    return "Game finished. Draw";
+  }
+
+  // возвращает массив из 4 углов квадрата (в порядке обхода) либо null
+  function findSquare(board, color){
+    var n = board.length;
+    var pts = [], set = new Set();
+    for (var y=0;y<n;y++) for (var x=0;x<n;x++){
+      if (board[y][x] === color){ pts.push([x,y]); set.add(y+"#"+x); }
+    }
+    if (pts.length < 4) return null;
+
+    for (var i=0;i<pts.length;i++){
+      var ax = pts[i][0], ay = pts[i][1];
+      for (var j=i+1;j<pts.length;j++){
+        var bx = pts[j][0], by = pts[j][1];
+        var vx = bx - ax, vy = by - ay;
+        if (vx===0 && vy===0) continue;
+
+        // вариант 1: поворот ребра на +90°
+        var cx1 = ax - vy, cy1 = ay + vx;
+        var dx1 = bx - vy, dy1 = by + vx;
+        if (inside(cx1,cy1,n) && inside(dx1,dy1,n) && set.has(cy1+"#"+cx1) && set.has(dy1+"#"+dx1)){
+          return [{x:ax,y:ay},{x:bx,y:by},{x:dx1,y:dy1},{x:cx1,y:cy1}];
+        }
+
+        // вариант 2: поворот на -90°
+        var cx2 = ax + vy, cy2 = ay - vx;
+        var dx2 = bx + vy, dy2 = by - vx;
+        if (inside(cx2,cy2,n) && inside(dx2,dy2,n) && set.has(cy2+"#"+cx2) && set.has(dy2+"#"+dx2)){
+          return [{x:ax,y:ay},{x:bx,y:by},{x:dx2,y:dy2},{x:cx2,y:cy2}];
+        }
+      }
+    }
+    return null;
+  }
+
+  function inside(x,y,n){ return x>=0 && y>=0 && x<n && y<n; }
+
+  /* ====== util ====== */
+  function boardToString(b){
+    var n=b.length, out='',y,x,v;
+    for(y=0;y<n;y++) for(x=0;x<n;x++){ v=b[y][x]; out += v? (v==='W'?'w':'b') : '.'; }
+    return out;
+  }
+  function logMove(c,x,y){
+    var d=document.createElement('div');
+    d.textContent=(c==='W'?'W':'B')+" ("+x+", "+y+")";
+    movesEl.appendChild(d); movesEl.scrollTop=1e6;
+  }
+  // если игра завершена — очищаем DOM-статус, чтобы не дублировать баннер на холсте
+  function setStatus(t){
+    if (state && state.finished) { statusEl.textContent = ""; return; }
+    statusEl.textContent = t;
+  }
+  function clamp(v,a,b){ return Math.max(a, Math.min(b, v)); }
+  function opp(c){ return c==='W'?'B':'W'; }
+  function who(c){ return c==='W'?'White':'Black'; }
+
+  function xhrJSON(method, url, obj, cb){
+    try{
+      var xhr = new XMLHttpRequest();
+      xhr.open(method, url, true);
+      xhr.setRequestHeader('Content-Type','application/json');
+      xhr.onreadystatechange = function(){
+        if (xhr.readyState !== 4) return;
+        if (xhr.status === 200){
+          try { cb(null, JSON.parse(xhr.responseText), 200); }
+          catch(e){ cb('bad json'); }
+        } else if (xhr.status === 204){
+          cb(null, null, 204);
+        } else cb('HTTP '+xhr.status);
+      };
+      xhr.send(JSON.stringify(obj));
+    }catch(e){ cb(e.message||String(e)); }
+  }
+})();

--- a/src/main/frontend/index.html
+++ b/src/main/frontend/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Squares</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar glass">
+    <button class="icon-btn" aria-label="menu">≡</button>
+    <h1>Squares</h1>
+    <div class="actions">
+      <button id="resetBtn" class="icon-btn" title="Restart">⟲</button>
+      <button id="fastBtn"  class="icon-btn" title="Auto move">➤</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <aside class="panel glass">
+      <div class="avatar"></div>
+      <div class="player-title">Player</div>
+
+      <div class="field">
+        <label>Board size</label>
+        <input id="sizeInp" type="number" min="3" max="20" value="11">
+      </div>
+
+      <div class="field">
+        <label>Play as</label>
+        <select id="colorSel">
+          <option value="W">White</option>
+          <option value="B">Black</option>
+        </select>
+      </div>
+
+      <button id="newBtn"  class="btn">New Game</button>
+      <button id="undoBtn" class="btn btn-ghost">Undo</button>
+
+      <div class="footnote">API: <span id="apiLabel"></span></div>
+    </aside>
+
+    <section class="board-wrap glass">
+      <canvas id="board"></canvas>
+      <div id="status" class="status"></div>
+    </section>
+
+    <aside class="panel glass">
+      <h3>Move Log</h3>
+      <div id="moves" class="moves"></div>
+    </aside>
+  </main>
+
+  <script>
+    // адрес твоего Java API
+    window.SQUARES_API = "http://127.0.0.1:3000/api/squares/nextMove";
+  </script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/src/main/frontend/styles.css
+++ b/src/main/frontend/styles.css
@@ -1,0 +1,138 @@
+:root{
+  --bg: #0e1217;
+  --panel: rgba(20,24,31,.55);
+  --stroke: rgba(255,255,255,.06);
+  --text: #e8ecf2;
+  --muted:#a6b0bf;
+
+  /* спокойные акценты */
+  --accent-a: #58d0ff;      /* холодный бирюзовый */
+  --accent-b: #ff74a8;      /* приглушённый розовый */
+
+  --glow-a: 0 0 24px rgba(88,208,255,.25);
+  --glow-b: 0 0 24px rgba(255,116,168,.25);
+
+  --radius: 16px;
+}
+
+/* базовая настройка страницы */
+*{ box-sizing: border-box; }
+html, body { height: 100%; }
+body{
+  margin:0;
+  color:var(--text);
+  background:
+    radial-gradient(1200px 700px at 20% -10%, rgba(88,208,255,.10), transparent 60%),
+    radial-gradient(1200px 700px at 80% 110%, rgba(255,116,168,.10), transparent 60%),
+    linear-gradient(180deg,#0b0f14,#10151b 40%, #0e1217 100%);
+  font: 14px/1.4 Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  overflow: hidden; /* убираем вертикальный скролл — всё внутри укладываем в 100vh */
+}
+
+/* glass card */
+.glass{
+  background: var(--panel);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius);
+  backdrop-filter: blur(10px) saturate(120%);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.06),
+    0 20px 60px rgba(0,0,0,.35);
+}
+
+/* верхняя панель */
+.topbar{
+  margin:16px auto 8px;
+  height:64px;
+  width:min(1280px, 96vw);
+  display:flex; align-items:center; justify-content:space-between;
+  padding:0 16px 0 10px; gap:10px;
+}
+.topbar h1{ margin:0; font-weight:700; letter-spacing:.5px; }
+.icon-btn{
+  width:40px; height:40px; border-radius:12px; border:1px solid var(--stroke);
+  color:var(--text); background:transparent; cursor:pointer;
+}
+.icon-btn:hover{ box-shadow: var(--glow-a), var(--glow-b); }
+
+/* основной лэйаут на всю высоту окна (минус топбар) */
+.layout{
+  width:min(1280px, 96vw);
+  margin:0 auto;
+  height:calc(100vh - 96px);          /* 64px бар + внешние отступы ≈ 96px */
+  display:grid;
+  grid-template-columns: 300px 1fr 300px;  /* панели пошире, центр максимум */
+  grid-template-rows: 1fr;
+  gap:18px;
+}
+
+/* боковые панели */
+.panel{ padding:16px; display:flex; flex-direction:column; gap:12px; height:100%; }
+.panel h3{ margin:0 0 6px; font-size:16px; }
+.avatar{
+  width:84px;height:84px;border-radius:50%;
+  border:1px dashed var(--stroke); align-self:flex-start; opacity:.7;
+}
+.player-title{ font-size:18px; margin-top:-4px; }
+.field{ display:flex; flex-direction:column; gap:6px; }
+input,select{
+  height:36px;border-radius:10px;border:1px solid var(--stroke);
+  background:#0b0f14;color:var(--text); padding:0 10px;
+}
+.btn{
+  height:40px;border-radius:12px;border:1px solid var(--stroke);
+  color:var(--text);
+  background:linear-gradient(90deg, rgba(88,208,255,.12), rgba(255,116,168,.12));
+  box-shadow: var(--glow-a), var(--glow-b);
+  cursor:pointer;
+}
+.btn-ghost{ background:transparent; box-shadow:none; }
+.btn:hover{ filter:brightness(1.05); }
+
+.footnote{
+  color:var(--muted); font-size:12px; margin-top:auto; opacity:.9; word-break:break-all;
+}
+
+/* центральная область с доской */
+.board-wrap{
+  position:relative;
+  display:flex; align-items:center; justify-content:center;
+  padding:12px;             /* компактнее, чтобы больше места отдать канвасу */
+  height:100%;
+  min-height:0;             /* важно, чтобы ребёнок grid не вылезал за пределы */
+}
+
+#board{
+  display:block;
+  width:100%; height:100%;  /* визуально занимаем всё — реальный пиксельный размер задаёт JS */
+  max-width:100%;
+  border-radius:12px;
+}
+
+.status{
+  position:absolute; bottom:8px; left:12px; right:12px; text-align:center;
+  color:var(--muted); font-weight:600; letter-spacing:.4px;
+}
+
+/* лог ходов */
+.moves{
+  height:100%;
+  overflow:auto;
+  padding-right:6px;
+}
+.moves > div{
+  padding:8px 6px; margin:6px 0;
+  background:rgba(255,255,255,.03);
+  border:1px solid var(--stroke);
+  border-radius:10px;
+}
+
+/* мобильная колоночная раскладка */
+@media (max-width:980px){
+  .layout{
+    grid-template-columns: 1fr;
+    height: calc(100vh - 96px);
+  }
+  .panel{ order:1; }
+  .board-wrap{ order:0; }
+}


### PR DESCRIPTION
## Что сделано
- Добавлен статический UI (Canvas) для игры «Квадраты»:
  - адаптивное поле с авто-масштабом (до 50×50);
  - лог ходов и Undo;
  - статус хода; финальный баннер «White/Black wins» ;
  - подсветка найденного квадрата-победителя;
  - если игрок выбирает Black — первым ходит ИИ (игрок ходит вторым).
- Корневой `package.json`:
  - `npm run dev:win` — одновременно поднимает UI и Java API (Windows);
  - `npm run dev:unix` — то же для macOS/Linux;
  - `npm run serve` — статическая выдача UI.
- Зависимости dev: `http-server`, `concurrently`.
- UI общается с REST-сервисом из задания 2: `POST /api/squares/nextMove`.

## Как запускать локально
```bash
# из корня репозитория
npm install

# Windows
npm run dev:win
# macOS / Linux
npm run dev:unix
